### PR TITLE
Add engineer task attribute support

### DIFF
--- a/import-relationships-from-discogs.user.js
+++ b/import-relationships-from-discogs.user.js
@@ -534,6 +534,11 @@ function getArtistRoles(artist) {
                     return setNativeValue(SELECTORS.TaskInput, rolePart[1].replace(']', '').trim().toLowerCase());
                 });
             }
+            if (mapping && mapping.linkType == 'engineer' && rolePart[1]) {
+                additionalAttributes.push(() => {
+                    return setNativeValue(SELECTORS.TaskInput, rolePart[1].replace(']', '').trim().toLowerCase());
+                });
+            }
             if (mapping && mapping.linkType == 'producer' && rolePart[1]) {
                 additionalAttributes.push(() => {
                     return setNativeValue(SELECTORS.TaskInput, rolePart[1].replace(']', '').trim().toLowerCase());

--- a/import-relationships-from-discogs.user.js
+++ b/import-relationships-from-discogs.user.js
@@ -2,7 +2,7 @@
 
 // @name           Import relationships from a discogs release in to a MusicBrainz release
 // @description    Add a button to import Discogs release relationships to MusicBrainz
-// @version        2023.12.04.2
+// @version        2023.12.06.1
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.githubusercontent.com/mattgoldspink/musicbrainz-userscripts/feature_fix_always_render_button/import-relationships-from-discogs.user.js
 // @updateURL      https://raw.githubusercontent.com/mattgoldspink/musicbrainz-userscripts/feature_fix_always_render_button/import-relationships-from-discogs.user.js


### PR DESCRIPTION
Added "engineer" **task** attribute support now that reosarevok added support for it, see also

https://community.metabrainz.org/t/relationship-types-artist-release-engineer-doesnt-have-the-task-attribute/668474/2
