### PR TITLE
Add mixer task attribute support

### DIFF
--- a/import-relationships-from-discogs.user.js
+++ b/import-relationships-from-discogs.user.js
@@ -539,6 +539,11 @@ function getArtistRoles(artist) {
                     return setNativeValue(SELECTORS.TaskInput, rolePart[1].replace(']', '').trim().toLowerCase());
                 });
             }
+            if (mapping && mapping.linkType == 'mixer' && rolePart[1]) {
+                additionalAttributes.push(() => {
+                    return setNativeValue(SELECTORS.TaskInput, rolePart[1].replace(']', '').trim().toLowerCase());
+                });
+            }
             if (mapping && mapping.linkType == 'producer' && rolePart[1]) {
                 additionalAttributes.push(() => {
                     return setNativeValue(SELECTORS.TaskInput, rolePart[1].replace(']', '').trim().toLowerCase());


### PR DESCRIPTION
Add support for the task attribute to the mixer role now that Reosarevok implemented it.
See also https://community.metabrainz.org/t/relationship-types-artist-release-engineer-doesnt-have-the-task-attribute/668474/3
